### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "version": "0.0.1",
-  "requirements": ["bluetooth-data-tools==1.19.0"]
+  "requirements": ["bluetooth-data-tools==1.20.0"]
 }


### PR DESCRIPTION
after installation, the integration was giving an error, editing the manifest.json to "requirements": ["bluetooth-data-tools==1.20.0"] this will allow the integration to work with the latest HA as of 18/11/2024. Other wise it just gives the same error and does not allow to add LD2450

![image](https://github.com/user-attachments/assets/1b2011f8-0d28-4442-9070-e701ada3b22a)
![image](https://github.com/user-attachments/assets/58a2cb9f-0b0d-4deb-b59c-f620e27c5caf)
